### PR TITLE
Improve Local Recording

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -71,6 +71,9 @@ class RecordCommand : Callable<Int> {
     @Option(names = ["--local"], description = ["(Beta) Record using local rendering. This will become the default in a future Maestro release."])
     private var local: Boolean = false
 
+    @Option(names = ["--only-on-failure"], description = ["Only render the recording if the Flow fails. The recording is discarded on success."])
+    private var onlyOnFailure: Boolean = false
+
     @Option(names = ["-e", "--env"])
     private var env: Map<String, String> = emptyMap()
 
@@ -164,17 +167,21 @@ class RecordCommand : Callable<Int> {
                     }
                 }
 
-                val frames = resultView.getFrames()
+                if (onlyOnFailure && exitCode == 0) {
+                    screenRecording.delete()
+                } else {
+                    val frames = resultView.getFrames()
 
-                val localOutputFile = outputFile ?: path.resolve("maestro-recording.mp4").toFile()
-                val videoRenderer = if (local) LocalVideoRenderer(
-                    frameRenderer = SkiaFrameRenderer(),
-                    outputFile = localOutputFile,
-                    outputFPS = 25,
-                    outputWidthPx = 1920,
-                    outputHeightPx = 1080,
-                ) else RemoteVideoRenderer()
-                videoRenderer.render(screenRecording, frames)
+                    val localOutputFile = outputFile ?: path.resolve("maestro-recording.mp4").toFile()
+                    val videoRenderer = if (local) LocalVideoRenderer(
+                        frameRenderer = SkiaFrameRenderer(),
+                        outputFile = localOutputFile,
+                        outputFPS = 25,
+                        outputWidthPx = 1920,
+                        outputHeightPx = 1080,
+                    ) else RemoteVideoRenderer()
+                    videoRenderer.render(screenRecording, frames)
+                }
 
                 TestDebugReporter.deleteOldFiles()
 

--- a/maestro-cli/src/main/java/maestro/cli/graphics/LocalVideoRenderer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/graphics/LocalVideoRenderer.kt
@@ -10,7 +10,13 @@ import org.jcodec.common.io.NIOUtils
 import org.jcodec.common.model.Rational
 import org.jcodec.scale.AWTUtil
 import java.awt.image.BufferedImage
+import java.awt.image.DataBufferByte
+import java.io.Closeable
 import java.io.File
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicReference
+import java.util.zip.CRC32
 
 interface FrameRenderer {
     fun render(
@@ -29,6 +35,51 @@ class LocalVideoRenderer(
     private val outputHeightPx: Int,
 ) : VideoRenderer {
 
+    private sealed class WorkItem {
+        data class Frame(val future: CompletableFuture<ByteArray>) : WorkItem()
+        object Repeat : WorkItem()
+        object End : WorkItem()
+    }
+
+    private data class VideoInfo(val width: Int, val height: Int, val durationSeconds: Double)
+
+    private fun probeVideo(file: File): VideoInfo {
+        val proc = ProcessBuilder(
+            "ffprobe", "-v", "error",
+            "-select_streams", "v:0",
+            "-show_entries", "stream=width,height,duration",
+            "-of", "csv=p=0",
+            file.absolutePath
+        ).redirectError(ProcessBuilder.Redirect.DISCARD).start()
+        val parts = proc.inputStream.bufferedReader().readText().trim().split(",")
+        val width = parts[0].toInt()
+        val height = parts[1].toInt()
+
+        // Stream-level duration is N/A for some container formats (e.g. MOV/MP4 recorded
+        // by iOS). Fall back to container-level duration in that case.
+        val duration = parts.getOrNull(2)?.toDoubleOrNull() ?: run {
+            val fmt = ProcessBuilder(
+                "ffprobe", "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "csv=p=0",
+                file.absolutePath
+            ).redirectError(ProcessBuilder.Redirect.DISCARD).start()
+            fmt.inputStream.bufferedReader().readText().trim().toDouble()
+        }
+
+        return VideoInfo(width, height, duration)
+    }
+
+    private fun startFfmpegDecode(file: File): Process {
+        return ProcessBuilder(
+            "ffmpeg", "-loglevel", "error",
+            "-i", file.absolutePath,
+            "-f", "rawvideo", "-pix_fmt", "bgr24",
+            "-r", "$outputFPS",
+            "pipe:1"
+        ).redirectError(ProcessBuilder.Redirect.INHERIT).start()
+    }
+
     override fun render(
         screenRecording: File,
         textFrames: List<AnsiResultView.Frame>,
@@ -39,40 +90,189 @@ class LocalVideoRenderer(
         System.err.println(outputFile.absolutePath)
 
         val uploadProgress = ProgressBar(50)
-        NIOUtils.writableFileChannel(outputFile.absolutePath).use { out ->
-            AWTSequenceEncoder(out, Rational.R(outputFPS, 1)).use { encoder ->
-                useFrameGrab(screenRecording) { grab ->
-                    val outputDurationSeconds = grab.videoTrack.meta.totalDuration
-                    val outputFrameCount = (outputDurationSeconds * outputFPS).toInt()
-                    var curFrame: PictureWithMetadata = grab.nativeFrameWithMetadata!!
-                    var nextFrame: PictureWithMetadata? = grab.nativeFrameWithMetadata
-                    (0..outputFrameCount).forEach { frameIndex ->
-                        val currentTimestampSeconds = frameIndex.toDouble() / outputFPS
+        val decodedTextFrames = textFrames.map { frame ->
+            frame to frame.content.decodeBase64()!!.string(Charsets.UTF_8).stripAnsiCodes()
+        }
 
-                        // !! Due to smart cast limitation: https://youtrack.jetbrains.com/issue/KT-7186
-                        @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
-                        while (nextFrame != null && nextFrame!!.timestamp <= currentTimestampSeconds) {
-                            curFrame = nextFrame!!
-                            nextFrame = grab.nativeFrameWithMetadata
+        val ffmpeg = startFfmpeg()
+        if (ffmpeg != null) {
+            renderWithFfmpeg(screenRecording, decodedTextFrames, uploadProgress, ffmpeg)
+        } else {
+            renderWithJCodec(screenRecording, decodedTextFrames, uploadProgress)
+        }
+
+        System.err.println()
+        System.err.println()
+        System.err.println("Rendering complete! If you're sharing on Twitter be sure to tag us 😄 @|bold @mobile__dev|@".render())
+    }
+
+    /**
+     * Fast path: FFmpeg subprocess (hardware encode/decode) + pipeline parallelism.
+     *
+     * Main thread: FFmpeg decode (VideoToolbox on macOS) → CRC dedup → BlockingQueue
+     * Render thread: Skia render → BGRbytes → FFmpeg stdin (skipped for Repeat frames)
+     * FFmpeg process: H.264 encode (hardware on macOS, software ultrafast elsewhere)
+     */
+    private fun renderWithFfmpeg(
+        screenRecording: File,
+        decodedTextFrames: List<Pair<AnsiResultView.Frame, String>>,
+        uploadProgress: ProgressBar,
+        ffmpeg: Process,
+    ) {
+        val parallelRenderer = ParallelSkiaRenderer(outputWidthPx = outputWidthPx, outputHeightPx = outputHeightPx)
+        val queue = LinkedBlockingQueue<WorkItem>(QUEUE_CAPACITY)
+        val renderError = AtomicReference<Throwable>()
+
+        val renderThread = Thread {
+            try {
+                ffmpeg.outputStream.buffered().use { stdin ->
+                    val bgrBytes = ByteArray(outputWidthPx * outputHeightPx * 3)
+                    while (true) {
+                        when (val item = queue.take()) {
+                            is WorkItem.End -> break
+                            is WorkItem.Repeat -> stdin.write(bgrBytes)
+                            is WorkItem.Frame -> {
+                                val bytes = item.future.get()
+                                bytes.copyInto(bgrBytes)
+                                stdin.write(bgrBytes)
+                            }
                         }
+                    }
+                }
+            } catch (e: Throwable) {
+                renderError.set(e)
+            }
+        }
+        renderThread.isDaemon = true
+        renderThread.start()
 
-                        val curImage = AWTUtil.toBufferedImage(curFrame.picture)
-                        val curTextFrame = textFrames.lastOrNull { frame -> frame.timestamp.div(1000.0) <= currentTimestampSeconds } ?: textFrames.first()
-                        val curText = curTextFrame.content.decodeBase64()!!.string(Charsets.UTF_8).stripAnsiCodes()
-                        val outputImage = frameRenderer.render(outputWidthPx, outputHeightPx, curImage, curText)
-                        encoder.encodeImage(outputImage)
+        val info = probeVideo(screenRecording)
+        val frameByteCount = info.width * info.height * 3
+        val estimatedFrameCount = (info.durationSeconds * outputFPS).toInt().coerceAtLeast(1)
 
-                        uploadProgress.set(frameIndex / outputFrameCount.toFloat())
+        val decodeProcess = startFfmpegDecode(screenRecording)
+        val decodeStream = decodeProcess.inputStream.buffered()
+        val rawBuffer = ByteArray(frameByteCount)
+        var prevCrc = 0L
+        var prevText: String? = null
+        var frameIndex = 0
+
+        try {
+            while (true) {
+                val bytesRead = decodeStream.readNBytes(rawBuffer, 0, frameByteCount)
+                if (bytesRead < frameByteCount) break
+
+                val currentTimestampSeconds = frameIndex.toDouble() / outputFPS
+                val curText = decodedTextFrames.lastOrNull { (frame, _) ->
+                    frame.timestamp.div(1000.0) <= currentTimestampSeconds
+                }?.second ?: decodedTextFrames.first().second
+
+                val crc = CRC32().apply { update(rawBuffer, 0, frameByteCount) }.value
+                if (crc == prevCrc && curText == prevText) {
+                    queue.put(WorkItem.Repeat)
+                } else {
+                    val screenImage = BufferedImage(info.width, info.height, BufferedImage.TYPE_3BYTE_BGR)
+                    System.arraycopy(rawBuffer, 0, (screenImage.raster.dataBuffer as DataBufferByte).data, 0, frameByteCount)
+                    val future = parallelRenderer.submit(screenImage, curText)
+                    queue.put(WorkItem.Frame(future))
+                    prevCrc = crc
+                    prevText = curText
+                }
+
+                uploadProgress.set(frameIndex / estimatedFrameCount.toFloat())
+                frameIndex++
+            }
+        } finally {
+            queue.put(WorkItem.End)
+            decodeProcess.destroyForcibly()
+            decodeProcess.waitFor()
+        }
+
+        renderThread.join()
+        parallelRenderer.close()
+        (frameRenderer as? Closeable)?.close()
+        renderError.get()?.let { throw RuntimeException("Render thread failed", it) }
+
+        val exitCode = ffmpeg.waitFor()
+        if (exitCode != 0) {
+            System.err.println("Warning: ffmpeg exited with code $exitCode")
+        }
+    }
+
+    /** Fallback path when ffmpeg is not installed. */
+    private fun renderWithJCodec(
+        screenRecording: File,
+        decodedTextFrames: List<Pair<AnsiResultView.Frame, String>>,
+        uploadProgress: ProgressBar,
+    ) {
+        (frameRenderer as? Closeable).use {
+            NIOUtils.writableFileChannel(outputFile.absolutePath).use { out ->
+                AWTSequenceEncoder(out, Rational.R(outputFPS, 1)).use { encoder ->
+                    useFrameGrab(screenRecording) { grab ->
+                        val outputDurationSeconds = grab.videoTrack.meta.totalDuration
+                        val outputFrameCount = (outputDurationSeconds * outputFPS).toInt()
+                        var curFrame: PictureWithMetadata = grab.nativeFrameWithMetadata!!
+                        var nextFrame: PictureWithMetadata? = grab.nativeFrameWithMetadata
+                        (0..outputFrameCount).forEach { frameIndex ->
+                            val currentTimestampSeconds = frameIndex.toDouble() / outputFPS
+
+                            // !! Due to smart cast limitation: https://youtrack.jetbrains.com/issue/KT-7186
+                            @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
+                            while (nextFrame != null && nextFrame!!.timestamp <= currentTimestampSeconds) {
+                                curFrame = nextFrame!!
+                                nextFrame = grab.nativeFrameWithMetadata
+                            }
+
+                            val curImage = AWTUtil.toBufferedImage(curFrame.picture)
+                            val curText = decodedTextFrames.lastOrNull { (frame, _) ->
+                                frame.timestamp.div(1000.0) <= currentTimestampSeconds
+                            }?.second ?: decodedTextFrames.first().second
+                            val outputImage = frameRenderer.render(outputWidthPx, outputHeightPx, curImage, curText)
+                            encoder.encodeImage(outputImage)
+
+                            uploadProgress.set(frameIndex / outputFrameCount.toFloat())
+                        }
                     }
                 }
             }
         }
-        System.err.println()
-        System.err.println()
-        System.err.println("Rendering complete! If you're sharing on Twitter be sure to tag us \uD83D\uDE04 @|bold @mobile__dev|@".render())
+    }
+
+    private fun startFfmpeg(): Process? {
+        val isMac = System.getProperty("os.name").lowercase().contains("mac")
+        val codec = if (isMac) "h264_videotoolbox" else "libx264"
+        val extraArgs = if (!isMac) listOf("-preset", "ultrafast") else emptyList()
+
+        return try {
+            ProcessBuilder(buildList {
+                addAll(listOf(
+                    "ffmpeg", "-y",
+                    "-loglevel", "error",
+                    "-f", "rawvideo",
+                    "-pix_fmt", "bgr24",
+                    "-s", "${outputWidthPx}x${outputHeightPx}",
+                    "-r", "$outputFPS",
+                    "-i", "pipe:0",
+                    "-c:v", codec,
+                    "-pix_fmt", "yuv420p",
+                    "-movflags", "+faststart",
+                ))
+                addAll(extraArgs)
+                add(outputFile.absolutePath)
+            })
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start()
+        } catch (e: Exception) {
+            System.err.println("ffmpeg not found, falling back to built-in encoder (slower)")
+            null
+        }
     }
 
     private fun String.stripAnsiCodes(): String {
         return replace("\\u001B\\[[;\\d]*[mH]".toRegex(), "")
+    }
+
+    companion object {
+        private const val QUEUE_CAPACITY = 8
     }
 }

--- a/maestro-cli/src/main/java/maestro/cli/graphics/ParallelSkiaRenderer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/graphics/ParallelSkiaRenderer.kt
@@ -1,0 +1,62 @@
+package maestro.cli.graphics
+
+import java.awt.image.BufferedImage
+import java.awt.image.DataBufferByte
+import java.io.Closeable
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.LinkedBlockingQueue
+
+class ParallelSkiaRenderer(
+    private val workerCount: Int = Runtime.getRuntime().availableProcessors(),
+    private val outputWidthPx: Int,
+    private val outputHeightPx: Int,
+) : Closeable {
+
+    private sealed class Job {
+        data class Render(
+            val future: CompletableFuture<ByteArray>,
+            val screen: BufferedImage,
+            val text: String,
+        ) : Job()
+        object Poison : Job()
+    }
+
+    private val jobQueue = LinkedBlockingQueue<Job>(workerCount * 2)
+
+    private val workers: List<Thread> = List(workerCount) {
+        Thread {
+            val renderer = SkiaFrameRenderer()
+            val bgrBuffer = BufferedImage(outputWidthPx, outputHeightPx, BufferedImage.TYPE_3BYTE_BGR)
+            val bgrGraphics = bgrBuffer.createGraphics()
+            val bgrBytes = (bgrBuffer.raster.dataBuffer as DataBufferByte).data
+            try {
+                while (true) {
+                    when (val job = jobQueue.take()) {
+                        is Job.Poison -> break
+                        is Job.Render -> try {
+                            val rendered = renderer.render(outputWidthPx, outputHeightPx, job.screen, job.text)
+                            bgrGraphics.drawImage(rendered, 0, 0, null)
+                            job.future.complete(bgrBytes.copyOf())
+                        } catch (e: Throwable) {
+                            job.future.completeExceptionally(e)
+                        }
+                    }
+                }
+            } finally {
+                bgrGraphics.dispose()
+                renderer.close()
+            }
+        }.also { it.isDaemon = true; it.start() }
+    }
+
+    fun submit(screen: BufferedImage, text: String): CompletableFuture<ByteArray> {
+        val future = CompletableFuture<ByteArray>()
+        jobQueue.put(Job.Render(future, screen, text))
+        return future
+    }
+
+    override fun close() {
+        repeat(workerCount) { jobQueue.put(Job.Poison) }
+        workers.forEach { it.join() }
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/graphics/SkiaFrameRenderer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/graphics/SkiaFrameRenderer.kt
@@ -8,9 +8,10 @@ import org.jetbrains.skia.Rect
 import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.toImage
 import java.awt.image.BufferedImage
+import java.io.Closeable
 import javax.imageio.ImageIO
 
-class SkiaFrameRenderer : FrameRenderer {
+class SkiaFrameRenderer : FrameRenderer, Closeable {
 
     private val backgroundImage = ImageIO.read(SkiaFrameRenderer::class.java.getResource("/record-background.jpg")!!).toImage()
 
@@ -41,16 +42,23 @@ class SkiaFrameRenderer : FrameRenderer {
 
     private val textClipper = SkiaTextClipper()
 
+    private var surface: Surface? = null
+
     override fun render(
         outputWidthPx: Int,
         outputHeightPx: Int,
         screen: BufferedImage,
         text: String
     ): BufferedImage {
-        return Surface.makeRasterN32Premul(outputWidthPx, outputHeightPx).use { surface ->
-            drawScene(surface.canvas, outputWidthPx.toFloat(), outputHeightPx.toFloat(), screen, text)
-            surface.makeImageSnapshot().toBufferedImage()
-        }
+        val s = surface?.takeIf { it.width == outputWidthPx && it.height == outputHeightPx }
+            ?: Surface.makeRasterN32Premul(outputWidthPx, outputHeightPx).also { surface = it }
+        drawScene(s.canvas, outputWidthPx.toFloat(), outputHeightPx.toFloat(), screen, text)
+        return s.makeImageSnapshot().toBufferedImage()
+    }
+
+    override fun close() {
+        surface?.close()
+        surface = null
     }
 
     private fun drawScene(canvas: Canvas, outputWidthPx: Float, outputHeightPx: Float, screen: BufferedImage, text: String) {

--- a/maestro-cli/src/main/java/maestro/cli/graphics/SkiaTextClipper.kt
+++ b/maestro-cli/src/main/java/maestro/cli/graphics/SkiaTextClipper.kt
@@ -15,14 +15,20 @@ import kotlin.math.min
 
 class SkiaTextClipper {
 
+    private val fontCollection = FontCollection().setDefaultFontManager(FontMgr.default)
+
     private val terminalTextStyle = TextStyle().apply {
         fontFamilies = SkiaFonts.MONOSPACE_FONT_FAMILIES.toTypedArray()
         fontSize = 24f
         color = Color.WHITE
     }
 
+    private var cachedParagraph: Paragraph? = null
+    private var cachedText: String? = null
+    private var cachedWidth: Float? = null
+
     fun renderClippedText(canvas: Canvas, rect: Rect, text: String, focusedLine: Int) {
-        val p = createParagraph(text, rect.width)
+        val p = getParagraph(text, rect.width)
         val focusedLineRange = getRangeForLine(text, focusedLine)
         val focusedLineBottom = p.getRectsForRange(
             start = focusedLineRange.first,
@@ -53,8 +59,18 @@ class SkiaTextClipper {
         return Pair(start, end)
     }
 
+    private fun getParagraph(text: String, width: Float): Paragraph {
+        if (text == cachedText && width == cachedWidth) {
+            return cachedParagraph!!
+        }
+        return createParagraph(text, width).also {
+            cachedParagraph = it
+            cachedText = text
+            cachedWidth = width
+        }
+    }
+
     private fun createParagraph(text: String, width: Float): Paragraph {
-        val fontCollection = FontCollection().setDefaultFontManager(FontMgr.default)
         return ParagraphBuilder(ParagraphStyle(), fontCollection)
             .pushStyle(terminalTextStyle)
             .addText(text)

--- a/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
+++ b/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
@@ -30,7 +30,7 @@ class XCTestDriverClientTest {
             setBody(mapper.writeValueAsString(error))
         }
         mockWebServer.enqueue(mockResponse)
-        mockWebServer.start(InetAddress.getByName("localhost"), 22087)
+        mockWebServer.start(InetAddress.getByName("localhost"), 0)
         val httpUrl = mockWebServer.url("/deviceInfo")
 
         // when
@@ -38,16 +38,18 @@ class XCTestDriverClientTest {
         val mockXCTestInstaller = MockXCTestInstaller(simulator)
         val xcTestDriverClient = XCTestDriverClient(
             mockXCTestInstaller,
-            XCTestClient("localhost", 22087)
+            XCTestClient("localhost", mockWebServer.port)
         )
 
-
         // then
-        assertThrows<XCUITestServerError.BadRequest> {
-            xcTestDriverClient.deviceInfo(httpUrl)
+        try {
+            assertThrows<XCUITestServerError.BadRequest> {
+                xcTestDriverClient.deviceInfo(httpUrl)
+            }
+            mockXCTestInstaller.assertInstallationRetries(0)
+        } finally {
+            mockWebServer.shutdown()
         }
-        mockXCTestInstaller.assertInstallationRetries(0)
-        mockWebServer.shutdown()
     }
 
     @Test
@@ -61,7 +63,7 @@ class XCTestDriverClientTest {
             setBody(mapper.writeValueAsString(expectedDeviceInfo))
         }
         mockWebServer.enqueue(mockResponse)
-        mockWebServer.start(InetAddress.getByName("localhost"), 22087)
+        mockWebServer.start(InetAddress.getByName("localhost"), 0)
         val httpUrl = mockWebServer.url("/deviceInfo")
 
         // when
@@ -69,14 +71,17 @@ class XCTestDriverClientTest {
         val mockXCTestInstaller = MockXCTestInstaller(simulator)
         val xcTestDriverClient = XCTestDriverClient(
             mockXCTestInstaller,
-            XCTestClient("localhost", 22087)
+            XCTestClient("localhost", mockWebServer.port)
         )
-        val actualDeviceInfo = xcTestDriverClient.deviceInfo(httpUrl)
 
         // then
-        assertThat(actualDeviceInfo).isEqualTo(expectedDeviceInfo)
-        mockXCTestInstaller.assertInstallationRetries(0)
-        mockWebServer.shutdown()
+        try {
+            val actualDeviceInfo = xcTestDriverClient.deviceInfo(httpUrl)
+            assertThat(actualDeviceInfo).isEqualTo(expectedDeviceInfo)
+            mockXCTestInstaller.assertInstallationRetries(0)
+        } finally {
+            mockWebServer.shutdown()
+        }
     }
 
     @ParameterizedTest
@@ -91,7 +96,7 @@ class XCTestDriverClientTest {
             setBody(mapper.writeValueAsString(expectedDeviceInfo))
         }
         mockWebServer.enqueue(mockResponse)
-        mockWebServer.start(InetAddress.getByName( "localhost"), 22087)
+        mockWebServer.start(InetAddress.getByName("localhost"), 0)
         val httpUrl = mockWebServer.url("/deviceInfo")
 
         // when
@@ -99,16 +104,18 @@ class XCTestDriverClientTest {
         val mockXCTestInstaller = MockXCTestInstaller(simulator)
         val xcTestDriverClient = XCTestDriverClient(
             mockXCTestInstaller,
-            XCTestClient("localhost", 22087)
+            XCTestClient("localhost", mockWebServer.port)
         )
 
-
         // then
-        assertThrows<XCUITestServerError.AppCrash> {
-            xcTestDriverClient.deviceInfo(httpUrl)
+        try {
+            assertThrows<XCUITestServerError.AppCrash> {
+                xcTestDriverClient.deviceInfo(httpUrl)
+            }
+            mockXCTestInstaller.assertInstallationRetries(0)
+        } finally {
+            mockWebServer.shutdown()
         }
-        mockXCTestInstaller.assertInstallationRetries(0)
-        mockWebServer.shutdown()
     }
 
     companion object {


### PR DESCRIPTION
## Summary
  - **FFmpeg fast path**: uses `h264_videotoolbox` on macOS (hardware encode) and
    `libx264 -preset ultrafast` elsewhere, falling back to JCodec if ffmpeg is
    not installed. Decode is also piped through ffmpeg for hardware-accelerated
    demux.
  - **Pipeline parallelism**: decode thread → CRC dedup → blocking queue → render
    thread → ffmpeg stdin. Encode and Skia rendering run concurrently.
  - **CRC frame dedup**: identical consecutive frames are detected via CRC32 and
    sent as repeats, skipping Skia renders for static screens (common in
    recordings).
  - **Parallel Skia rendering** (`ParallelSkiaRenderer`): one worker thread per
    CPU core, each with its own `SkiaFrameRenderer`, maximising render throughput.
  - **Surface caching** in `SkiaFrameRenderer`: reuses the Skia `Surface` across
    frames instead of reallocating per frame.
  - **Paragraph caching** in `SkiaTextClipper`: skips re-layout when text and
    width are unchanged; `FontCollection` moved to instance level (was recreated
    per paragraph).
  - **`--only-on-failure` flag**: discards the recording when the flow succeeds,
    useful for CI pipelines.